### PR TITLE
Add configurable race-style countdown sounds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.14.1'
+def runeLiteVersion = '1.7.24'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/duckblade/runelite/summergarden/SummerGardenConfig.java
+++ b/src/main/java/com/duckblade/runelite/summergarden/SummerGardenConfig.java
@@ -2,10 +2,8 @@ package com.duckblade.runelite.summergarden;
 
 import java.awt.Color;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.Units;
+import net.runelite.api.SoundEffectVolume;
+import net.runelite.client.config.*;
 
 @ConfigGroup(SummerGardenPlugin.CONFIG_GROUP)
 public interface SummerGardenConfig extends Config
@@ -120,6 +118,43 @@ public interface SummerGardenConfig extends Config
 	default boolean useGateStartPoint()
 	{
 		return false;
+	}
+
+
+	// Race-style countdown  -Green Donut
+	@ConfigSection(
+			name = "Race-Style Countdown",
+			description = "Options for the race-style countdown",
+			position = 11,
+			closedByDefault = true
+	)
+	String raceStyleSection = "raceStyle";
+
+	@ConfigItem(
+			keyName = SummerGardenPlugin.CONFIG_KEY_RACE_STYLE_COUNTDOWN,
+			name = "Enable race-style countdown",
+			description = "Plays race-style countdown sounds on the last few ticks before and when the player needs to click the tree.",
+			position = 1,
+			section = raceStyleSection
+	)
+	default boolean raceStyleCountdown()
+	{
+		return false;
+	}
+
+	@Range(
+			max = SoundEffectVolume.HIGH
+	)
+	@ConfigItem(
+			keyName = SummerGardenPlugin.CONFIG_KEY_RACE_STYLE_VOLUME,
+			name = "Race-style volume",
+			description = "Configures the volume of the race-style countdown sounds.",
+			position = 2,
+			section = raceStyleSection
+	)
+	default int raceStyleVolume()
+	{
+		return SoundEffectVolume.MEDIUM_HIGH;
 	}
 
 }

--- a/src/main/java/com/duckblade/runelite/summergarden/SummerGardenPlugin.java
+++ b/src/main/java/com/duckblade/runelite/summergarden/SummerGardenPlugin.java
@@ -52,10 +52,14 @@ public class SummerGardenPlugin extends Plugin
 	public static final String CONFIG_GROUP = "oneclicksummergarden";
 	public static final String CONFIG_KEY_GATE_START = "useGateStartPoint";
 	public static final String CONFIG_KEY_COUNTDOWN_TIMER_INFOBOX = "showCountdownTimer";
+	public static final String CONFIG_KEY_RACE_STYLE_COUNTDOWN = "raceStyleCountdown";
+	public static final String CONFIG_KEY_RACE_STYLE_VOLUME = "raceStyleVolume";
 	private static final WorldPoint GARDEN = new WorldPoint(2915, 5490, 0);
 	private static final String STAMINA_MESSAGE = "[One Click Summer Garden] Low Stamina Warning";
 	private static final String CYCLE_MESSAGE = "[One Click Summer Garden] Cycle Ready";
 	private static final int SUMMER_SQUIRK_ITEM_ID = 10845;
+	private static final int RACE_STYLE_SOUND_LOW = 3817;
+	private static final int RACE_STYLE_SOUND_HIGH = 3818;
 
 	private InfoBox countdownTimerInfoBox;
 	private boolean sentStaminaNotification = false;
@@ -159,6 +163,29 @@ public class SummerGardenPlugin extends Plugin
 		if (config.cycleNotification() && collisionDetector.getTicksUntilStart() == config.notifyTicksBeforeStart())
 		{
 			notifier.notify(CYCLE_MESSAGE, TrayIcon.MessageType.INFO);
+		}
+
+		// Race-style countdown  -Green Donut
+		if (config.raceStyleCountdown() && collisionDetector.getTicksUntilStart() <= 3 && config.raceStyleVolume() > 0)
+		{
+			// As playSoundEffect only uses the volume argument when the in-game volume isn't muted, sound effect volume
+			// needs to be set to the value desired for race sounds and afterwards reset to the previous value.
+			Preferences preferences = client.getPreferences();
+			int previousVolume = preferences.getSoundEffectVolume();
+			preferences.setSoundEffectVolume(config.raceStyleVolume());
+
+			switch (collisionDetector.getTicksUntilStart())
+			{
+				// high sound for countdown 0
+				case 0:
+					client.playSoundEffect(RACE_STYLE_SOUND_HIGH, config.raceStyleVolume());
+					break;
+				// low sound for countdown 3,2,1
+				default:
+					client.playSoundEffect(RACE_STYLE_SOUND_LOW, config.raceStyleVolume());
+					break;
+			}
+			preferences.setSoundEffectVolume(previousVolume);
 		}
 
 		// check for stamina usage


### PR DESCRIPTION
- Disabled by default, players can have mario-kart style sounds (town crier sounds) play the last few ticks before they need to click the tree
- Created a new section in config for the race-style countdown sound settings
- Sounds can be enabled/disabled
- Sound volume can be adjusted

This feature was something I had in mind since it allows me to look away for a bit while knowing exactly when to click. Racing countdowns are also something that every elite gamer has engrained in their brains and this feature has replicated that perfectly for me. Pls merge.